### PR TITLE
fix: make CI link checker fail on http:// drupal.org links

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -136,8 +136,8 @@ jobs:
       - name: Check for broken internal links
         run: |
           echo "Checking for common issues..."
-          # Check .claude/ and root-level markdown files for http:// drupal.org links (should use https)
-          if grep -rn --include="*.md" "http://drupal\.org\|http://www\.drupal\.org" .claude/ .; then
+          # Check all markdown files for http:// drupal.org links (should use https)
+          if grep -rn --include="*.md" --exclude-dir=.git "http://drupal\.org\|http://www\.drupal\.org" .; then
             echo "Error: Found http:// links to drupal.org — use https:// instead"
             exit 1
           fi

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -136,12 +136,9 @@ jobs:
       - name: Check for broken internal links
         run: |
           echo "Checking for common issues..."
-          # Check for http:// links to drupal.org (should use https)
-          if grep -r "http://drupal.org" .claude/; then
-            echo "Warning: Found http:// links to drupal.org, should use https://"
-          fi
-          # Check for http://www.drupal.org
-          if grep -r "http://www.drupal.org" .claude/; then
-            echo "Warning: Found http:// links to www.drupal.org, should use https://"
+          # Check .claude/ and root-level markdown files for http:// drupal.org links (should use https)
+          if grep -rn --include="*.md" "http://drupal\.org\|http://www\.drupal\.org" .claude/ .; then
+            echo "Error: Found http:// links to drupal.org — use https:// instead"
+            exit 1
           fi
           echo "Link check complete"


### PR DESCRIPTION
## Problem

The link checker step in `validate.yml` warned when `http://` links to drupal.org were found, but never called `exit 1` — so the check was purely advisory and would pass silently even if insecure links were introduced. A CI check that doesn't fail isn't a gate.

Additionally, the check only scanned `.claude/` but not root-level markdown files (README.md, ROADMAP.md, etc.).

## Changes

- **Enforcing**: Add `exit 1` when http:// drupal.org links are found
- **Broader scope**: Extend scan to include root-level `*.md` files alongside `.claude/`
- **Simpler**: Combine both `drupal.org` and `www.drupal.org` patterns into one `grep` call with `--include="*.md"` to avoid matching non-markdown files

## Verified

Ran the check locally — no http:// drupal.org links exist in the current codebase, so CI remains green after this change.

```bash
$ grep -rn --include="*.md" "http://drupal\.org\|http://www\.drupal\.org" .claude/ .
$ echo $?
1  # nothing found, check passes
```

## Test plan

- [ ] CI passes on this PR (no existing http:// links to break it)
- [ ] Verify: adding a test `http://drupal.org` link to any .md file fails the build

🤖 Generated with [Claude Code](https://claude.ai/claude-code)