### PR TITLE
ci: flag legacy @Annotation-style plugin declarations

### DIFF
--- a/.claude/skills/drupal-expert/SKILL.md
+++ b/.claude/skills/drupal-expert/SKILL.md
@@ -812,20 +812,11 @@ return ['#markup' => $this->t('Submit form')];
 **Use PHP attributes for plugins** (works in D10.2+, required style for D11):
 
 ```php
-// Modern style (D10.2+, required for D11)
 #[Block(
   id: 'my_block',
   admin_label: new TranslatableMarkup('My Block'),
 )]
 class MyBlock extends BlockBase {}
-
-// Legacy style (still works but discouraged)
-/**
- * @Block(
- *   id = "my_block",
- *   admin_label = @Translation("My Block"),
- * )
- */
 ```
 
 **Use OOP hooks** (D10.3+):

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -143,3 +143,12 @@ jobs:
             exit 1
           fi
           echo "Link check complete"
+
+      - name: Check for legacy annotation-style plugin declarations
+        run: |
+          echo "Checking for legacy @Annotation-style plugin declarations (should use PHP 8 attributes)..."
+          if grep -rEn --include="*.md" --exclude-dir=.git '@Block\(|@EntityType\(|@FieldType\(|@FieldWidget\(|@FieldFormatter\(|@Plugin\(' .; then
+            echo "Error: Found legacy @Annotation-style plugin declaration, use PHP 8 attributes instead"
+            exit 1
+          fi
+          echo "Annotation check complete"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -57,15 +57,6 @@ This document outlines planned improvements and new resources for the drupal-age
 
 **Example Patterns**:
 ```php
-// Old D10 annotation style
-/**
- * @Block(
- *   id = "example_block",
- *   admin_label = @Translation("Example block")
- * )
- */
-
-// New D11 attribute style
 #[Block(
   id: 'example_block',
   admin_label: new TranslatableMarkup('Example block')


### PR DESCRIPTION
Follows up on the suggestion in #9, after the discussion in #11.

## What

Adds a CI check that fails when any markdown file contains legacy Drupal annotation-style plugin declarations (`@Block(`, `@EntityType(`, `@FieldType(`, `@FieldWidget(`, `@FieldFormatter(`, `@Plugin(`). These were superseded by PHP 8 attributes in Drupal 10/11.

Also removes two legacy examples that triggered the new check:

- `.claude/skills/drupal-expert/SKILL.md` — dropped the `@Block(` contrast block (the deprecation table above already communicates this)
- `ROADMAP.md` — dropped the `@Block(` side of the before/after comparison

Skills exist to teach Claude what to produce, not what to recognise. Keeping the old syntax as a reference risks it being picked up as a valid output pattern.

## CI step added

```bash
if grep -rEn --include="*.md" --exclude-dir=.git \
  '@Block\(|@EntityType\(|@FieldType\(|@FieldWidget\(|@FieldFormatter\(|@Plugin\(' .; then
  echo "Error: Found legacy @Annotation-style plugin declaration, use PHP 8 attributes instead"
  exit 1
fi
```

## Verified

Both the link check and annotation check pass on the current repo state.

Closes #11.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)